### PR TITLE
Relax Dart version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.3
+## 0.0.4
 
 - Updated allowed Dart version to include 3.0.5
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.0.3
 
+- Updated allowed Dart version to include 3.0.5
+ 
+## 0.0.3
+
 - Updated README.md image rendering for better compatibility on pub.dev.
 
 ## 0.0.2

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the following line to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  bitcoin_icons: ^0.0.1
+  bitcoin_icons: ^0.0.4
 ```
 
 Then run `flutter pub get` to fetch the package.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aniketambore/bitcoin_icons
 license: MIT
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.5'
   flutter: ">=1.17.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aniketambore/bitcoin_icons
 license: MIT
 
 environment:
-  sdk: '>=2.19.0 <3.0.5'
+  sdk: '>=2.19.0 <=3.0.5'
   flutter: ">=1.17.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bitcoin_icons
 description: This Package provides a comprehensive collection of icons specifically designed for Bitcoin applications.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/aniketambore/bitcoin_icons
 repository: https://github.com/aniketambore/bitcoin_icons
 license: MIT

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/aniketambore/bitcoin_icons
 license: MIT
 
 environment:
-  sdk: '>=2.19.0 <=3.0.5'
+  sdk: '>=2.18.0 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Updated to allow for wider Dart versions, 2.18.0 to less than 4.0.0
Version bumped to 0.0.4